### PR TITLE
Update 2017-02-19-understanding-symbolic-links.md

### DIFF
--- a/_posts/2017-02-19-understanding-symbolic-links.md
+++ b/_posts/2017-02-19-understanding-symbolic-links.md
@@ -21,11 +21,13 @@ note_body: >-
 
 ![](http://i.imgur.com/IKCybXy.png)
 
+{% include alert.html type="info" message="This post assumes you have a [basic grasp of Linux commands](http://linuxcommand.org/learning_the_shell.php) such as [apt-get](https://help.ubuntu.com/community/AptGet/Howto) and [linux file permissions](https://help.ubuntu.com/community/FilePermissions), as well as some of the [SSH workflow tips covered previously](http://blog.johannesmp.com/2017/02/11/ssh-workflow-tips/)." %}
+
 Symbolic links, or *"Symlinks"* are a fundamental part of the Linux toolbox. They allow you to make a file or folder accessible from another location as if by reference.
 
 Symbolic links are used ***everywhere*** in Linux. Many applications like [apache](https://httpd.apache.org/) and [nginx](https://www.nginx.com/resources/wiki/) require them for their configuration files, and they can be a powerful tool for your workflow.
 
-{% include alert.html type="info" message="This post assumes you have a [basic grasp of Linux commands](http://linuxcommand.org/learning_the_shell.php) such as [apt-get](https://help.ubuntu.com/community/AptGet/Howto) and [linux file permissions](https://help.ubuntu.com/community/FilePermissions), as well as some of the [SSH workflow tips covered previously](http://blog.johannesmp.com/2017/02/11/ssh-workflow-tips/)." %}
+
 
 <!-- more -->
 
@@ -82,7 +84,7 @@ To create a symbolic link we use the [**`ln`** command](https://en.wikipedia.org
 ln -s <path/to/source> <path/to/link>
 ```
 
-To mirror the *C++ reference* example above, let's create **`a.txt`** and a symbolic link named **`s_a.txt`**:
+To mirror the reference example above, let's create **`a.txt`** and a symbolic link named **`s_a.txt`**:
 
 ```bash
 echo "1" > a.txt      # 'a.txt' is a text file that contains '1'
@@ -96,10 +98,9 @@ We can now access the data, as well as modify it through the symlink:
 ![](https://i.imgur.com/83gpBiA.png)
 
 You can also create a symbolic link to a directory, then interact with it as if it was a real folder:
-
 ![](https://i.imgur.com/d1bS1T8.png)
 
-A symbolic link is technically **neither a file nor a directory**. How it is interpreted depends only on the path it was created with, and what that path contains when the symbolic link is evaluated.
+A symbolic link is technically neither a file nor a directory. How it is interpreted depends only on the path it was created with, and what that path contains when the symbolic link is evaluated.
 
 
 <br />
@@ -115,7 +116,7 @@ If we remove the original directory **`b`**, the symbolic link is now invalid (a
 
 ![](https://i.imgur.com/YMj9kc2.png)
 
-If we now create a **text file** named **`b`** then the same symbolic link **`s_b`** will now point to that file:
+If we now create a text file named **`b`** then the same symbolic link **`s_b`** will now point to that file:
 
 ![](https://i.imgur.com/qwp4Aoj.png)
 
@@ -155,9 +156,10 @@ With a web servers like *apache2* or *nginx* you would have to reload a config f
 ### Config File Management
 Most Applications on Linux store their configuration files in **`/etc/<appname>`**
 
-For example, *mysql* might store its configuration files in **`/etc/mysql/`**, *php5*  could have its files in **`/etc/php5/apache2/`**, etc.
+For example, *mysql* might store its configuration files in **`/etc/mysql/`**,
+*php5*  could have its files in **`/etc/php5/apache2/`**, etc.
 
-While you *could* modify each file on its own as necessary, this is not very maintainable in the long run:
+While you could modify each file on its own as necessary, this is not very maintainable in the long run:
 
 - If you ever want to set up a similar configuration on another server, you'll have to hunt for the files.
 - If you ever need to revert a configuration to a previous state, you will have no way to do so.
@@ -183,7 +185,7 @@ Furthermore, several Linux applications that have config files in **`/etc/`** ha
 
 For example, while the default configuration file for *php5* might be **`/etc/php5/apache2/php.ini`**, it also provides a directory **`/etc/php5/apache2/conf.d/`**, and any config file stored there (including symlinks) will be loaded after the default config file.
 
-This lends itself really well to symlinks. you can store all of your configuration files in one place, and then only symlink the ones you need on a given server.
+This lends itself really well to symlinks by design, and is demonstrative of Linux design in general. You can store all of your configuration files in one place, and then only symlink the ones you need on a given server.
 
 
 


### PR DESCRIPTION
I would move the disclaimer about previous knowledge to the top of the file so that it is the first thing that people do if they are uncomfortable.
I don't agree with 'neither a file nor a directory' being bolded, because while it is a useful thing to know, I don't think it's core to the lesson that is trying to be taught here, and overall I felt the article had an overuse of bolding. Similarly, 'text file' on line 119 does not need to be bolded, especially since 'directory' is not bolded earlier in the section.
Line 159 was split after the comma, because the formatting didn't look good in the blog format due to the italics and directory notation being right next to each other before a new line.
Italics were removed from 'could' on line 162, as italics are used for concept or program names, not emphasis throughout the rest of the article.
Line 188 changes are tentative, but it makes it seem like it's a surprise that symlinks work well for config files rather than being a representative example of Linux design.
I feel like the article needs a conclusion but I'm not sure what it would be.